### PR TITLE
Support for the new LyCORIS directory

### DIFF
--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -124,11 +124,11 @@ onUiUpdate(function() {
   /* ################### ^ DEPRICATED ^ ############################ */
 
   // Sync the refresh main model list button
-  registerClickEvents(gradioApp().querySelector('#refresh_sd_model_checkpoint'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
+  registerClickEvents(gradioApp().querySelector('#refresh_sd_model_checkpoint'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#ly_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
 
   // Sync the new refresh extra network buttons to this extension
-  registerClickEvents(gradioApp().querySelector('#txt2img_extra_refresh'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
-  registerClickEvents(gradioApp().querySelector('#img2img_extra_refresh'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
+  registerClickEvents(gradioApp().querySelector('#txt2img_extra_refresh'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#ly_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
+  registerClickEvents(gradioApp().querySelector('#img2img_extra_refresh'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#ly_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
 
   // Find the radio buttons used in the setting page and add a tooltip to them
   let name_matching_setting = gradioApp().querySelector("#settings_model_preview_xd #setting_model_preview_xd_name_matching .gr-input-label:not([title])")

--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -200,6 +200,10 @@ onUiUpdate(function() {
         case "img2img_lora_cards":
           modelToSelect = "Lora";
         break;
+        case "txt2img_lycoris_cards":
+        case "img2img_lycoris_cards":
+          modelToSelect = "LyCORIS";
+        break;
         case "txt2img_checkpoints_cards":
         case "img2img_checkpoints_cards":
           modelToSelect = "Checkpoints";
@@ -240,6 +244,10 @@ function doCardClick(event, name, modelType) {
           case "Lora":
             modelNameID = "lo_modelpreview_xd_update_sd_model_text";
             modelUpdateID = "lo_modelpreview_xd_update_sd_model";
+          break;
+          case "LyCORIS":
+            modelNameID = "ly_modelpreview_xd_update_sd_model_text";
+            modelUpdateID = "ly_modelpreview_xd_update_sd_model";
           break;
           case "Embeddings":
             modelNameID = "em_modelpreview_xd_update_sd_model_text";

--- a/style.css
+++ b/style.css
@@ -71,6 +71,7 @@
 #tab_modelpreview_xd_interface #cp_modelpreview_xd_html_row,
 #tab_modelpreview_xd_interface #em_modelpreview_xd_html_row,
 #tab_modelpreview_xd_interface #hn_modelpreview_xd_html_row,
+#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_row,
 #tab_modelpreview_xd_interface #lo_modelpreview_xd_html_row {
 	flex: 1;
 	overflow: auto;
@@ -79,14 +80,17 @@
 #tab_modelpreview_xd_interface #cp_modelpreview_xd_html_div > .transition,
 #tab_modelpreview_xd_interface #em_modelpreview_xd_html_div > .transition,
 #tab_modelpreview_xd_interface #hn_modelpreview_xd_html_div > .transition,
+#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_div > .transition,
 #tab_modelpreview_xd_interface #lo_modelpreview_xd_html_div > .transition,
 #tab_modelpreview_xd_interface #cp_modelpreview_xd_html_div > div:nth-of-type(2),
 #tab_modelpreview_xd_interface #em_modelpreview_xd_html_div > div:nth-of-type(2),
 #tab_modelpreview_xd_interface #hn_modelpreview_xd_html_div > div:nth-of-type(2),
+#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_div > div:nth-of-type(2),
 #tab_modelpreview_xd_interface #lo_modelpreview_xd_html_div > div:nth-of-type(2),
 #tab_modelpreview_xd_interface #cp_modelpreview_xd_html_div,
 #tab_modelpreview_xd_interface #em_modelpreview_xd_html_div,
 #tab_modelpreview_xd_interface #hn_modelpreview_xd_html_div,
+#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_div,
 #tab_modelpreview_xd_interface #lo_modelpreview_xd_html_div {
 	height: 100%;
 }
@@ -99,6 +103,7 @@
 #tab_modelpreview_xd_interface #cp_modelpreview_xd_hidden_ui,
 #tab_modelpreview_xd_interface #em_modelpreview_xd_hidden_ui,
 #tab_modelpreview_xd_interface #hn_modelpreview_xd_hidden_ui,
+#tab_modelpreview_xd_interface #ly_modelpreview_xd_hidden_ui,
 #tab_modelpreview_xd_interface #lo_modelpreview_xd_hidden_ui {
 	display: none;
 }
@@ -106,6 +111,7 @@
 #tab_modelpreview_xd_interface #cp_modelpreview_xd_flexcolumn_row,
 #tab_modelpreview_xd_interface #em_modelpreview_xd_flexcolumn_row,
 #tab_modelpreview_xd_interface #hn_modelpreview_xd_flexcolumn_row,
+#tab_modelpreview_xd_interface #ly_modelpreview_xd_flexcolumn_row,
 #tab_modelpreview_xd_interface #lo_modelpreview_xd_flexcolumn_row {
 	flex-direction: column;
 }
@@ -120,12 +126,14 @@
 #cp_modelpreview_xd_html_div .img-meta,
 #em_modelpreview_xd_html_div .img-meta,
 #hn_modelpreview_xd_html_div .img-meta,
+#ly_modelpreview_xd_html_div .img-meta,
 #lo_modelpreview_xd_html_div .img-meta {
 	display: none;
 }
 #cp_modelpreview_xd_html_div .img-meta-ico::before,
 #em_modelpreview_xd_html_div .img-meta-ico::before,
 #hn_modelpreview_xd_html_div .img-meta-ico::before,
+#ly_modelpreview_xd_html_div .img-meta-ico::before,
 #lo_modelpreview_xd_html_div .img-meta-ico::before {
 	content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' fill='%23ffffff' width='1em' x='0px' y='0px' viewBox='0 0 115.77 122.88' style='enable-background:new 0 0 115.77 122.88' xml:space='preserve'%3E%3Cstyle type='text/css'%3E.st0%7Bfill-rule:evenodd;clip-rule:evenodd;%7D%3C/style%3E%3Cg%3E%3Cpath class='st0' d='M89.62,13.96v7.73h12.19h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02v0.02 v73.27v0.01h-0.02c-0.01,3.84-1.57,7.33-4.1,9.86c-2.51,2.5-5.98,4.06-9.82,4.07v0.02h-0.02h-61.7H40.1v-0.02 c-3.84-0.01-7.34-1.57-9.86-4.1c-2.5-2.51-4.06-5.98-4.07-9.82h-0.02v-0.02V92.51H13.96h-0.01v-0.02c-3.84-0.01-7.34-1.57-9.86-4.1 c-2.5-2.51-4.06-5.98-4.07-9.82H0v-0.02V13.96v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07V0h0.02h61.7 h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02V13.96L89.62,13.96z M79.04,21.69v-7.73v-0.02h0.02 c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v64.59v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h12.19V35.65 v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07v-0.02h0.02H79.04L79.04,21.69z M105.18,108.92V35.65v-0.02 h0.02c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v73.27v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h61.7h0.02 v0.02c0.91,0,1.75-0.39,2.37-1.01c0.61-0.61,1-1.46,1-2.37h-0.02V108.92L105.18,108.92z'/%3E%3C/g%3E%3C/svg%3E");
 	color: white;
@@ -149,12 +157,14 @@
 #cp_modelpreview_xd_html_div .img-meta-ico,
 #em_modelpreview_xd_html_div .img-meta-ico,
 #hn_modelpreview_xd_html_div .img-meta-ico,
+#ly_modelpreview_xd_html_div .img-meta-ico,
 #lo_modelpreview_xd_html_div .img-meta-ico {
 	display: inline-block;
 }
 #cp_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
 #em_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
 #hn_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
+#ly_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
 #lo_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before {
 	background: #f00;
 }
@@ -162,6 +172,7 @@
 #cp_modelpreview_xd_html_div .img-container-set,
 #em_modelpreview_xd_html_div .img-container-set,
 #hn_modelpreview_xd_html_div .img-container-set,
+#ly_modelpreview_xd_html_div .img-container-set,
 #lo_modelpreview_xd_html_div .img-container-set {
 	display: flex;
 	flex-wrap: wrap;
@@ -177,6 +188,7 @@
 #cp_modelpreview_xd_html_div .img-container-set .img-container,
 #em_modelpreview_xd_html_div .img-container-set .img-container,
 #hn_modelpreview_xd_html_div .img-container-set .img-container,
+#ly_modelpreview_xd_html_div .img-container-set .img-container,
 #lo_modelpreview_xd_html_div .img-container-set .img-container {
 	position: relative;
 	border: 1px solid grey;
@@ -188,6 +200,7 @@
 #cp_modelpreview_xd_html_div .img-container-set .img-container img,
 #em_modelpreview_xd_html_div .img-container-set .img-container img,
 #hn_modelpreview_xd_html_div .img-container-set .img-container img,
+#ly_modelpreview_xd_html_div .img-container-set .img-container img,
 #lo_modelpreview_xd_html_div .img-container-set .img-container img {
 	object-fit: contain;
 	height: 100%;
@@ -200,6 +213,7 @@
     #cp_modelpreview_xd_html_div .img-container-set .img-container,
     #em_modelpreview_xd_html_div .img-container-set .img-container,
     #hn_modelpreview_xd_html_div .img-container-set .img-container,
+    #ly_modelpreview_xd_html_div .img-container-set .img-container,
     #lo_modelpreview_xd_html_div .img-container-set .img-container {
 		width: 193px;
 		height: 194px;
@@ -210,6 +224,7 @@
     #cp_modelpreview_xd_html_div .img-container-set .img-container,
     #em_modelpreview_xd_html_div .img-container-set .img-container,
     #hn_modelpreview_xd_html_div .img-container-set .img-container,
+    #ly_modelpreview_xd_html_div .img-container-set .img-container,
     #lo_modelpreview_xd_html_div .img-container-set .img-container {
 		width: 193px;
 		height: 194px;


### PR DESCRIPTION
With the latest updates to the LyCORIS extension https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris, LyCORIS models are now separated from base LoRA models.

There's now a new tab for LyCORIS models in extra networks tab. This change adds an equivalent tab to the models preview extension for LyCORIS models.