### PR TITLE
Prompt list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ This extension allows you to create various types of preview files/notes[^previe
 2. Paste `https://github.com/CurtisDS/sd-model-preview-xd` into the url box.
 3. Click Install
 4. From the Installed tab click apply and restart[^2].
-5. Put `.html`[^3], `.md`[^3], `.txt`, `.png`, `.webp`, `.jpg`/`.jpeg`, and/or `.tags`[^4] files in the same directory as your models, or a subfolder. Make sure to name the files the same as your model. You may append something after the name of the model and it will still work ([See: Name Matching Rules](#name-matching-rules)). You can have multiple images for a single model, but only one markdown, text, or html file. You can also mix and match any of the preview files except for HTML files, if the extension finds an html file it will only show the html file.
+5. Put `.html`[^3], `.md`[^3], `.txt`, `.png`, `.webp`, `.jpg`/`.jpeg`, `.prompt`[^4], and/or `.tags`[^5] files in the same directory as your models, or a subfolder. Make sure to name the files the same as your model. You may append something after the name of the model and it will still work ([See: Name Matching Rules](#name-matching-rules)). You can have multiple images for a single model, but only one markdown, text, or html file. You can also mix and match any of the preview files except for HTML files, if the extension finds an html file it will only show the html file.
 
 [^2]: If you run into issues after first install you may need to fully shutdown and rerun the webui-user.bat after you install the extension.
 [^3]: HTML and Markdown files will not support linking to files or images outside of the Automatic1111 directory. If you cannot keep linked files within the install directory upload them to the internet and link to them remotely.
-[^4]: A `.tags` file is just a text file containing words that you want to use for searching for the associated model. It is suggested you format this as a list of hashtags. For example: `"#anime #sfw #mix #high_quality"`. This will help avoid matching `"nsfw"` when searching for `"sfw"`. However there is no *required* format. A search will match as long as the search text appears anywhere in the file.
+[^4]: A `.prompt` file is a CSV file containing a list of prompts associated with your model.
+[^5]: A `.tags` file is just a text file containing words that you want to use for searching for the associated model. It is suggested you format this as a list of hashtags. For example: `"#anime #sfw #mix #high_quality"`. This will help avoid matching `"nsfw"` when searching for `"sfw"`. However there is no *required* format. A search will match as long as the search text appears anywhere in the file.
+
 
 ***Note**: If you are using symlinks or otherwise changing the default model directories [click here for information](#changing-default-directories)*
 
@@ -35,7 +37,7 @@ This extension supports the following model types in the the default directories
 1. After creating the preview files and putting them in the corresponding directories, select the Model Preview tab in web ui and then the type of model you want to preview
 2. Select a model from the dropdown list. (If the model has any preview files they will be shown)
 3. Any preview png files found that also contain prompt data embedded in them will have a red "copy" button when hovering over the image. By clicking the button it will copy the prompt data to your clipboard.
-4. If you would like to filter the list of models enter text in the filter text box. The filter text will be separated by commas and return models who have that text anywhere in its name or its associated `.tags`[^4] file.
+4. If you would like to filter the list of models enter text in the filter text box. The filter text will be separated by commas and return models who have that text anywhere in its name or its associated `.tags`[^5] file.
 
 ![screenshot](https://github.com/CurtisDS/sd-model-preview-xd/raw/main/sd-model-preview-xd.png)
 

--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -1,4 +1,4 @@
-let previwTab = null;
+let previewTab = null;
 
 // Sync the refresh button for list with the invisible refresh button in the extension
 function registerClickEvents(refreshButton, invisible_button_id_selectors) {
@@ -51,7 +51,7 @@ function setSelectValue(selectPreviewModelElement, selectSDModelElement) {
 // Is fired by automatic1111 when the UI is updated
 onUiUpdate(function() {
   // There is a script containing settings for height
-  // Get the element and set the attribute to limit the hieght
+  // Get the element and set the attribute to limit the height
   let tabEl = gradioApp().getElementById('tab_modelpreview_xd_interface');
   let jsonEl = gradioApp().getElementById('modelpreview_xd_setting_json');
   if (typeof tabEl != 'undefined' && typeof jsonEl != 'undefined') {
@@ -67,9 +67,9 @@ onUiUpdate(function() {
   if(typeof selectSDModelElement != "undefined" && selectSDModelElement != null) {
     // Get the select element for the preview model list
     const selectPreviewModelElement = gradioApp().querySelector('#cp_mp2_preview_model_list select');
-    // Only register a new event if you havent already
+    // Only register a new event if you haven't already
     if (selectPreviewModelElement != "undefined" && selectPreviewModelElement != null && selectSDModelElement.getAttribute('md_preview_listener') !== 'true') {
-      // Set this attribute to true so we dont set the same listener again
+      // Set this attribute to true so we don't set the same listener again
       selectSDModelElement.setAttribute('md_preview_listener', 'true');
       // Add an event handler that will update the select with the new value if someone changes the checkpoint
       selectSDModelElement.addEventListener('change', (event) => setSelectValue(selectPreviewModelElement, selectSDModelElement));
@@ -85,7 +85,7 @@ onUiUpdate(function() {
     }
   }
 
-  /* ################### v DEPRICATED v ############################ */
+  /* ################### v DEPRECATED v ############################ */
 
   // Get the select element for the SD model checkpoint
   const selectHypernetworkElement = gradioApp().querySelector('#setting_sd_hypernetwork select');
@@ -121,7 +121,7 @@ onUiUpdate(function() {
     }
   });
   
-  /* ################### ^ DEPRICATED ^ ############################ */
+  /* ################### ^ DEPRECATED ^ ############################ */
 
   // Sync the refresh main model list button
   registerClickEvents(gradioApp().querySelector('#refresh_sd_model_checkpoint'), ['#cp_modelpreview_xd_refresh_sd_model','#lo_modelpreview_xd_refresh_sd_model','#ly_modelpreview_xd_refresh_sd_model','#hn_modelpreview_xd_refresh_sd_model','#em_modelpreview_xd_refresh_sd_model']);
@@ -164,7 +164,7 @@ onUiUpdate(function() {
   if(typeof tabs != "undefined" && tabs != null && tabs.length > 0) {
     tabs.forEach(tab => {
       if(tab.innerText == "Model Pre​views") {
-        previwTab = tab;
+        previewTab = tab;
       }
     });
   }
@@ -235,7 +235,7 @@ function doCardClick(event, name, modelType) {
         let modelNameID = null;
         let modelUpdateID = null;
 
-        // get the appropriate ids for the invisible text and button elements that will let us programtically set the dropdown later
+        // get the appropriate ids for the invisible text and button elements that will let us programmatically set the dropdown later
         switch (modelType) {
           case "Hypernetwork":
             modelNameID = "hn_modelpreview_xd_update_sd_model_text";
@@ -265,17 +265,17 @@ function doCardClick(event, name, modelType) {
 
         if(typeof modelName != "undefined" && modelName != null && 
            typeof modelUpdate != "undefined" && modelUpdate != null) {
-          // set the textares value
+          // set the textarea's value
           modelName.value = name;
           
-          // dispatch an event to triger the gradio update for the textarea
+          // dispatch an event to trigger the gradio update for the textarea
           const inputEvent = new Event("input");
           modelName.dispatchEvent(inputEvent);
           // click the update button to trigger the python code to set the dropdown
           modelUpdate.click();
           // click on the model preview tab now that we have selected the right preview
           setTimeout((event) => {
-            previwTab.click();
+            previewTab.click();
           }, 100);
         }
       }

--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -309,6 +309,7 @@ function imageZoomIn(event) {
   document.body.appendChild(overlay);
 }
 
-function copyOnClick(target) {
-  navigator.clipboard.writeText(target.innerText);
+function copyToClipboard(x) {
+  navigator.clipboard.writeText(x.join(', '));
+  return x;
 }

--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -308,3 +308,7 @@ function imageZoomIn(event) {
   // append the overlay div to the body
   document.body.appendChild(overlay);
 }
+
+function copyOnClick(target) {
+  navigator.clipboard.writeText(target.innerText);
+}

--- a/scripts/modelpreview.py
+++ b/scripts/modelpreview.py
@@ -242,13 +242,12 @@ def list_all_loras():
 	search_for_tags(lora_choices, tags["loras"], get_lora_dirs())
 	return lora_choices
 
-
 def list_all_lycorii():
 	global lycoris_choices, lycoris_module
-	# create an empty set for lycora models
+	# create an empty set for lycoris models
 	lycorii = set()
 
-	# import/update the lycora module
+	# import/update the lycoris module
 	lycoris_module = import_lycoris_module()
 	if lycoris_module is not None:
 		# copy the list of models
@@ -288,10 +287,9 @@ def refresh_loras(choice = None, filter = None):
 	lora_choices = list_all_loras()
 	return filter_loras(filter), *show_lora_preview(choice)
 
-
 def refresh_lycorii(choice = None, filter = None):
 	global lycoris_choices
-	# update the choices for the lora list
+	# update the choices for the lycoris list
 	lycoris_choices = list_all_lycorii()
 	return filter_lycorii(filter), *show_lycoris_preview(choice)
 
@@ -321,7 +319,6 @@ def filter_loras(filter=None):
 	filtered_lora_choices = filter_choices(lora_choices, filter, tags["loras"])
 	return gr.Dropdown.update(choices=filtered_lora_choices)
 
-
 def filter_lycorii(filter=None):
 	filtered_lycoris_choices = filter_choices(lycoris_choices, filter, tags["lycoris"])
 	return gr.Dropdown.update(choices=filtered_lycoris_choices)
@@ -345,7 +342,6 @@ def update_lora(name):
 	# update the selected preview for lora tab
 	new_choice = find_choice(lora_choices, name)
 	return new_choice, *show_lora_preview(new_choice)
-
 
 def update_lycorii(name):
 	# update the selected preview for LyCORIS tab
@@ -623,8 +619,17 @@ def get_lycoris_dirs():
 	# create list of directories
 	directories = []
 
+	# add directories from the third party lycoris extension if exists
 	if lycoris_module is not None:
-		directories.append(shared.cmd_opts.lyco_dir)
+		# add models/lora just in case to the list of directories
+		default_dir = os.path.join("models","LyCORIS") # models/Lora
+		if os.path.exists(default_dir) and os.path.isdir(default_dir):
+			directories.append(default_dir)
+		# add directories from the third party lycoris extension if exists
+		set_dir = shared.cmd_opts.lyco_dir
+		if set_dir is not None and not is_dir_in_list(directories, set_dir):
+			# WARNING: html files and markdown files that link to local files outside of the automatic1111 directory will not work correctly
+			directories.append(set_dir)
 
 	return directories
 
@@ -695,7 +700,7 @@ def show_preview(modelname, paths, tags_key):
 		prompts_update = gr.HTML.update(value=html, visible=True)
 	else:
 		prompts_update = gr.HTML.update(visible=False)
-	
+
 	# if images were found or an HTML file was found update the gradio html element
 	if html_code:
 		html_update = gr.HTML.update(value=preview_html, visible=True)
@@ -795,7 +800,6 @@ def on_ui_tabs():
 	# import/update the lora module
 	additional_networks = import_lora_module()
 	additional_networks_builtin = import_lora_module_builtin()
-
 	lycoris_module = import_lycoris_module()
 
 	# create a gradio block

--- a/scripts/modelpreview.py
+++ b/scripts/modelpreview.py
@@ -721,24 +721,24 @@ def show_preview(modelname, paths, tags_key):
 
 def create_tab(tab_label, tab_id_key, list_choices, show_preview_fn, filter_fn, refresh_fn, update_selected_fn):
 	# create a tab for model previews
-	with gr.Tab(tab_label, elem_id=f"model_preview_xd_{tab_label.lower()}_tab"):
-		with gr.Row():
-			list = gr.Dropdown(label="Model", choices=list_choices, interactive=True, elem_id=f"{tab_id_key}_mp2_preview_model_list")
-			filter_input = gr.Textbox(label="Filter", value="")
-		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_hidden_ui"):
-			refresh_list = gr.Button(value=refresh_symbol, elem_id=f"{tab_id_key}_modelpreview_xd_refresh_sd_model")
-			update_model_input = gr.Textbox(value="", elem_id=f"{tab_id_key}_modelpreview_xd_update_sd_model_text")
-			update_model_button = gr.Button(value=update_symbol, elem_id=f"{tab_id_key}_modelpreview_xd_update_sd_model")
+	with gr.Tab(tab_label, elem_id=f"model_preview_xd_{tab_label.lower()}_tab", elem_classes="model_preview_xd_tab"):
+		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_control_row", elem_classes="modelpreview_xd_control_row"):
+			list = gr.Dropdown(label="Model", choices=list_choices, interactive=True, elem_id=f"{tab_id_key}_mp2_preview_model_list", elem_classes="mp2_preview_model_list")
+			filter_input = gr.Textbox(label="Filter", value="", elem_id=f"{tab_id_key}_modelpreview_xd_filter_text", elem_classes="modelpreview_xd_filter_text")
+		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_hidden_ui", elem_classes="modelpreview_xd_hidden_ui"):
+			refresh_list = gr.Button(value=refresh_symbol, elem_id=f"{tab_id_key}_modelpreview_xd_refresh_sd_model", elem_classes="modelpreview_xd_refresh_sd_model")
+			update_model_input = gr.Textbox(value="", elem_id=f"{tab_id_key}_modelpreview_xd_update_sd_model_text", elem_classes="modelpreview_xd_update_sd_model_text")
+			update_model_button = gr.Button(value=update_symbol, elem_id=f"{tab_id_key}_modelpreview_xd_update_sd_model", elem_classes="modelpreview_xd_update_sd_model")
 		with gr.Row():
 			prompts_html = gr.HTML(elem_id=f"{tab_id_key}_modelpreview_xd_prompts_div", visible=False)
-		with gr.Row():
-			notes_text_area = gr.Textbox(label='Notes', interactive=False, lines=1, visible=False, elem_id=f"{tab_id_key}_modelpreview_xd_update_sd_model_text_area")
-		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_html_row"):
-			with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_flexcolumn_row"):
-				preview_html = gr.HTML(elem_id=f"{tab_id_key}_modelpreview_xd_html_div", visible=False)
-				preview_md = gr.Markdown(elem_id=f"{tab_id_key}_modelpreview_xd_markdown_div", visible=False)
-		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_tags_row"):
-			preview_tags = gr.HTML(elem_id=f"{tab_id_key}_modelpreview_xd_tags_div", visible=False)
+		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_notes_row", elem_classes="modelpreview_xd_notes_row"):
+			notes_text_area = gr.Textbox(label='Notes', interactive=False, lines=1, visible=False, elem_id=f"{tab_id_key}_modelpreview_xd_update_sd_model_text_area", elem_classes="modelpreview_xd_update_sd_model_text_area")
+		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_html_row", elem_classes="modelpreview_xd_html_row"):
+			with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_flexcolumn_row", elem_classes="modelpreview_xd_flexcolumn_row"):
+				preview_html = gr.HTML(elem_id=f"{tab_id_key}_modelpreview_xd_html_div", elem_classes="modelpreview_xd_html_div", visible=False)
+				preview_md = gr.Markdown(elem_id=f"{tab_id_key}_modelpreview_xd_markdown_div", elem_classes="modelpreview_xd_markdown_div", visible=False)
+		with gr.Row(elem_id=f"{tab_id_key}_modelpreview_xd_tags_row", elem_classes="modelpreview_xd_tags_row"):
+			preview_tags = gr.HTML(elem_id=f"{tab_id_key}_modelpreview_xd_tags_div", elem_classes="modelpreview_xd_tags_div", visible=False)
 
 	list.change(
 		fn=show_preview_fn,

--- a/style.css
+++ b/style.css
@@ -209,6 +209,25 @@
 	cursor: zoom-in;
 }
 
+#tab_modelpreview_xd_interface .prompt-label {
+	display: inline-block;
+    border-radius: 3px;
+    padding: 0 .5em;
+    background: var(--primary-500);
+    color: #ffffff;
+    font-weight: 600;
+    margin: .25em .1em;
+	user-select: all;
+    -moz-user-select: all;
+    -webkit-user-select: all;
+	cursor: pointer;
+}
+#tab_modelpreview_xd_interface .prompt-label:after {
+	content: '📋';
+	margin-left: 1px;
+}
+
+
 @media (max-height: 1000px) {
     #cp_modelpreview_xd_html_div .img-container-set .img-container,
     #em_modelpreview_xd_html_div .img-container-set .img-container,

--- a/style.css
+++ b/style.css
@@ -68,30 +68,14 @@
 	height: 100%;
 }
 
-#tab_modelpreview_xd_interface #cp_modelpreview_xd_html_row,
-#tab_modelpreview_xd_interface #em_modelpreview_xd_html_row,
-#tab_modelpreview_xd_interface #hn_modelpreview_xd_html_row,
-#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_row,
-#tab_modelpreview_xd_interface #lo_modelpreview_xd_html_row {
+#tab_modelpreview_xd_interface .modelpreview_xd_html_row {
 	flex: 1;
 	overflow: auto;
 }
 
-#tab_modelpreview_xd_interface #cp_modelpreview_xd_html_div > .transition,
-#tab_modelpreview_xd_interface #em_modelpreview_xd_html_div > .transition,
-#tab_modelpreview_xd_interface #hn_modelpreview_xd_html_div > .transition,
-#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_div > .transition,
-#tab_modelpreview_xd_interface #lo_modelpreview_xd_html_div > .transition,
-#tab_modelpreview_xd_interface #cp_modelpreview_xd_html_div > div:nth-of-type(2),
-#tab_modelpreview_xd_interface #em_modelpreview_xd_html_div > div:nth-of-type(2),
-#tab_modelpreview_xd_interface #hn_modelpreview_xd_html_div > div:nth-of-type(2),
-#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_div > div:nth-of-type(2),
-#tab_modelpreview_xd_interface #lo_modelpreview_xd_html_div > div:nth-of-type(2),
-#tab_modelpreview_xd_interface #cp_modelpreview_xd_html_div,
-#tab_modelpreview_xd_interface #em_modelpreview_xd_html_div,
-#tab_modelpreview_xd_interface #hn_modelpreview_xd_html_div,
-#tab_modelpreview_xd_interface #ly_modelpreview_xd_html_div,
-#tab_modelpreview_xd_interface #lo_modelpreview_xd_html_div {
+#tab_modelpreview_xd_interface .modelpreview_xd_html_div > .transition,
+#tab_modelpreview_xd_interface .modelpreview_xd_html_div > div:nth-of-type(2),
+#tab_modelpreview_xd_interface .modelpreview_xd_html_div {
 	height: 100%;
 }
 
@@ -100,19 +84,11 @@
 	height: 100%;
 }
 
-#tab_modelpreview_xd_interface #cp_modelpreview_xd_hidden_ui,
-#tab_modelpreview_xd_interface #em_modelpreview_xd_hidden_ui,
-#tab_modelpreview_xd_interface #hn_modelpreview_xd_hidden_ui,
-#tab_modelpreview_xd_interface #ly_modelpreview_xd_hidden_ui,
-#tab_modelpreview_xd_interface #lo_modelpreview_xd_hidden_ui {
+#tab_modelpreview_xd_interface .modelpreview_xd_hidden_ui {
 	display: none;
 }
 
-#tab_modelpreview_xd_interface #cp_modelpreview_xd_flexcolumn_row,
-#tab_modelpreview_xd_interface #em_modelpreview_xd_flexcolumn_row,
-#tab_modelpreview_xd_interface #hn_modelpreview_xd_flexcolumn_row,
-#tab_modelpreview_xd_interface #ly_modelpreview_xd_flexcolumn_row,
-#tab_modelpreview_xd_interface #lo_modelpreview_xd_flexcolumn_row {
+#tab_modelpreview_xd_interface .modelpreview_xd_flexcolumn_row {
 	flex-direction: column;
 }
 
@@ -123,18 +99,10 @@
 }
 
 /* Meta Copy Styling */
-#cp_modelpreview_xd_html_div .img-meta,
-#em_modelpreview_xd_html_div .img-meta,
-#hn_modelpreview_xd_html_div .img-meta,
-#ly_modelpreview_xd_html_div .img-meta,
-#lo_modelpreview_xd_html_div .img-meta {
+.modelpreview_xd_html_div .img-meta {
 	display: none;
 }
-#cp_modelpreview_xd_html_div .img-meta-ico::before,
-#em_modelpreview_xd_html_div .img-meta-ico::before,
-#hn_modelpreview_xd_html_div .img-meta-ico::before,
-#ly_modelpreview_xd_html_div .img-meta-ico::before,
-#lo_modelpreview_xd_html_div .img-meta-ico::before {
+.modelpreview_xd_html_div .img-meta-ico::before {
 	content: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' fill='%23ffffff' width='1em' x='0px' y='0px' viewBox='0 0 115.77 122.88' style='enable-background:new 0 0 115.77 122.88' xml:space='preserve'%3E%3Cstyle type='text/css'%3E.st0%7Bfill-rule:evenodd;clip-rule:evenodd;%7D%3C/style%3E%3Cg%3E%3Cpath class='st0' d='M89.62,13.96v7.73h12.19h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02v0.02 v73.27v0.01h-0.02c-0.01,3.84-1.57,7.33-4.1,9.86c-2.51,2.5-5.98,4.06-9.82,4.07v0.02h-0.02h-61.7H40.1v-0.02 c-3.84-0.01-7.34-1.57-9.86-4.1c-2.5-2.51-4.06-5.98-4.07-9.82h-0.02v-0.02V92.51H13.96h-0.01v-0.02c-3.84-0.01-7.34-1.57-9.86-4.1 c-2.5-2.51-4.06-5.98-4.07-9.82H0v-0.02V13.96v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07V0h0.02h61.7 h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02V13.96L89.62,13.96z M79.04,21.69v-7.73v-0.02h0.02 c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v64.59v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h12.19V35.65 v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07v-0.02h0.02H79.04L79.04,21.69z M105.18,108.92V35.65v-0.02 h0.02c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v73.27v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h61.7h0.02 v0.02c0.91,0,1.75-0.39,2.37-1.01c0.61-0.61,1-1.46,1-2.37h-0.02V108.92L105.18,108.92z'/%3E%3C/g%3E%3C/svg%3E");
 	color: white;
 	text-shadow: 1px 1px 1px black;
@@ -154,26 +122,14 @@
 	height: 30px;
 	transition: background-color 0.3s;
 }
-#cp_modelpreview_xd_html_div .img-meta-ico,
-#em_modelpreview_xd_html_div .img-meta-ico,
-#hn_modelpreview_xd_html_div .img-meta-ico,
-#ly_modelpreview_xd_html_div .img-meta-ico,
-#lo_modelpreview_xd_html_div .img-meta-ico {
+.modelpreview_xd_html_div .img-meta-ico {
 	display: inline-block;
 }
-#cp_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
-#em_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
-#hn_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
-#ly_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before,
-#lo_modelpreview_xd_html_div .img-container .img-meta-ico:hover::before {
+.modelpreview_xd_html_div .img-container .img-meta-ico:hover::before {
 	background: #f00;
 }
 
-#cp_modelpreview_xd_html_div .img-container-set,
-#em_modelpreview_xd_html_div .img-container-set,
-#hn_modelpreview_xd_html_div .img-container-set,
-#ly_modelpreview_xd_html_div .img-container-set,
-#lo_modelpreview_xd_html_div .img-container-set {
+.modelpreview_xd_html_div .img-container-set {
 	display: flex;
 	flex-wrap: wrap;
 	width: max-content;
@@ -185,11 +141,7 @@
 	margin: auto;
 	max-width: 100%;
 }
-#cp_modelpreview_xd_html_div .img-container-set .img-container,
-#em_modelpreview_xd_html_div .img-container-set .img-container,
-#hn_modelpreview_xd_html_div .img-container-set .img-container,
-#ly_modelpreview_xd_html_div .img-container-set .img-container,
-#lo_modelpreview_xd_html_div .img-container-set .img-container {
+.modelpreview_xd_html_div .img-container-set .img-container {
 	position: relative;
 	border: 1px solid grey;
 	width: 293px;
@@ -197,11 +149,7 @@
 	overflow: hidden;
 	background: #333;
 }
-#cp_modelpreview_xd_html_div .img-container-set .img-container img,
-#em_modelpreview_xd_html_div .img-container-set .img-container img,
-#hn_modelpreview_xd_html_div .img-container-set .img-container img,
-#ly_modelpreview_xd_html_div .img-container-set .img-container img,
-#lo_modelpreview_xd_html_div .img-container-set .img-container img {
+.modelpreview_xd_html_div .img-container-set .img-container img {
 	object-fit: contain;
 	height: 100%;
 	width: 100%;
@@ -229,22 +177,14 @@
 
 
 @media (max-height: 1000px) {
-    #cp_modelpreview_xd_html_div .img-container-set .img-container,
-    #em_modelpreview_xd_html_div .img-container-set .img-container,
-    #hn_modelpreview_xd_html_div .img-container-set .img-container,
-    #ly_modelpreview_xd_html_div .img-container-set .img-container,
-    #lo_modelpreview_xd_html_div .img-container-set .img-container {
+    .modelpreview_xd_html_div .img-container-set .img-container {
 		width: 193px;
 		height: 194px;
 	}
 }
 
 @media (max-width: 1300px) {
-    #cp_modelpreview_xd_html_div .img-container-set .img-container,
-    #em_modelpreview_xd_html_div .img-container-set .img-container,
-    #hn_modelpreview_xd_html_div .img-container-set .img-container,
-    #ly_modelpreview_xd_html_div .img-container-set .img-container,
-    #lo_modelpreview_xd_html_div .img-container-set .img-container {
+    .modelpreview_xd_html_div .img-container-set .img-container {
 		width: 193px;
 		height: 194px;
 	}

--- a/style.css
+++ b/style.css
@@ -157,25 +157,6 @@
 	cursor: zoom-in;
 }
 
-#tab_modelpreview_xd_interface .prompt-label {
-	display: inline-block;
-    border-radius: 3px;
-    padding: 0 .5em;
-    background: var(--primary-500);
-    color: #ffffff;
-    font-weight: 600;
-    margin: .25em .1em;
-	user-select: all;
-    -moz-user-select: all;
-    -webkit-user-select: all;
-	cursor: pointer;
-}
-#tab_modelpreview_xd_interface .prompt-label:after {
-	content: '📋';
-	margin-left: 1px;
-}
-
-
 @media (max-height: 1000px) {
     .modelpreview_xd_html_div .img-container-set .img-container {
 		width: 193px;


### PR DESCRIPTION
Adds a new preview file type `*.prompt` that produces a list of copyable prompts associated with the given model.

I've found this really handy for keeping track of the prompts in the myriad lora that I have in my library now.

Clicking a prompt copies it to the clipboard.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/31093750/232190445-ed0a34d3-6c18-41e6-92af-cdfeaf25d309.png">
