### PR TITLE
Correct embedded UTF-8 in tab name

### DIFF
--- a/javascript/event_handlers.js
+++ b/javascript/event_handlers.js
@@ -99,7 +99,7 @@ onUiUpdate(function() {
   let tabs = gradioApp().querySelectorAll("#tabs > div:first-of-type button");
   if(typeof tabs != "undefined" && tabs != null && tabs.length > 0) {
     tabs.forEach(tab => {
-      if(tab.innerText == "Model Pre​views") {
+      if(tab.innerText == "Model Previews") {
         previewTab = tab;
       }
     });

--- a/scripts/modelpreview.py
+++ b/scripts/modelpreview.py
@@ -1153,7 +1153,7 @@ def on_ui_tabs():
 					   refresh_lycorii,
 					   update_lycorii)
 	
-	return (modelpreview_interface, "Model Pre​views", "modelpreview_xd_interface"),
+	return (modelpreview_interface, "Model Previews", "modelpreview_xd_interface"),
 
 def on_ui_settings():
 	section = ('model_preview_xd', "Model Preview XD")


### PR DESCRIPTION
* This is showing up as "Model Pre Views" as the tab when it should be "Model Previews".